### PR TITLE
ci: improve vitest execution time on CI

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -16,6 +16,7 @@ export default defineConfig({
   test: {
     environment: "happy-dom",
     exclude: [...configDefaults.exclude, "**/e2e/**/*", "**/*.test.{j,t}sx"],
+    pool: "forks",
     reporters: ["default", "hanging-process"],
   },
 });

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -16,5 +16,6 @@ export default defineConfig({
   test: {
     environment: "happy-dom",
     exclude: [...configDefaults.exclude, "**/e2e/**/*", "**/*.test.{j,t}sx"],
+    reporters: ["default", "hanging-process"],
   },
 });


### PR DESCRIPTION
Fixes #2

Vitestのログから`hanging-proces` reporterを有効化すると寄り情報が得られそうなので有効化する

https://vitest.dev/config/#reporters